### PR TITLE
📝 Add missing documentation

### DIFF
--- a/content/docs/installation.md
+++ b/content/docs/installation.md
@@ -84,6 +84,14 @@ For convenience, Laracord comes with a console command to set a specified user a
 $ php laracord bot:admin <id>
 ```
 
+### Tinker (REPL)
+
+Laracord comes with full support for [Tinker](https://github.com/laravel/tinker) out of the box.
+
+```sh
+$ php laracord tinker
+```
+
 ### Additional Commands
 
 To view all built-in console commands, you can run the `list` command:

--- a/content/docs/messages.md
+++ b/content/docs/messages.md
@@ -28,22 +28,36 @@ This gives you a sensibly styled embed with the username and avatar of your bot.
 
 ![Simple Message](/images/simple-message.png)
 
-To send a plain message without an embed, you may pass your content to the `->body()` method:
+### Replying to Messages
+
+When sending messages, an easy way to improve user experience is to have the bot reply to a user when responding to their commands/input instead of just sending the message openly into the channel.
+
+To do this, you must have some sort of context to respond to whether it be an existing message or interaction.
 
 ```php
 $this
-    ->message()
-    ->body('Hello world!');
+    ->message('Hello to you!')
+    ->reply($message|$interaction);
 ```
 
-## Direct Usage
+### Editing Messages
 
-When `$this->message()` is not available in your class, you can typically access and make `Message` directly:
+Similar to replying, Laracord also lets you easily edit existing messages and interactions.
 
 ```php
-use Laracord\Discord\Message;
+$this
+    ->message('Nevermind...')
+    ->edit($message|$interaction);
+```
 
-Message::make()->content('Hello world!');
+Under the hood, this will update an existing interaction message using `$interaction->updateMessage()` or an existing message using `$message->edit()`.
+
+Another common scenario you might run into is the need to edit an existing message if it is owned by the bot otherwise replying instead.
+
+```php
+$this
+    ->message('Hello world')
+    ->editOrReply($message|$interaction);
 ```
 
 ## Available Methods
@@ -69,7 +83,6 @@ Message::make()->content('Hello world!');
 - [Select Menus](#content-select-menus)
   - [Menu Types](#content-menu-types)
 
-
 ### Title
 
 Set the title of the embed:
@@ -82,7 +95,7 @@ $this
 
 ### URL
 
-Set the url of the title:
+Set the URL of the title:
 
 ```php
 $this
@@ -103,12 +116,22 @@ $this
 
 ### Body
 
-Set the body of the embed, that send a message before the embed:
+The message body in Laracord refers to a message's generic content outside of the stylized embed that Laracord uses by default. This is otherwise the typical format that messages are sent and received on Discord.
+
+One limitation of stylizing message output as an embed is the inabiliity to send a notification to a user/role when mentioning them. One way to remedy this is to pass the mention into `->body()` making it appear above the embed in a mostly non-invasive way:
 
 ```php
 $this
     ->message('Hello world!')
     ->body('@everyone');
+```
+
+There may be a time where you do not want Laracord to send your message using an embed. In this case, simply pass your message content using `->body()` without specifying a message directly to `->message()` or `->content()`:
+
+```php
+$this
+    ->message()
+    ->body('Hello world!');
 ```
 
 ### Username

--- a/content/docs/slash-commands.md
+++ b/content/docs/slash-commands.md
@@ -168,3 +168,65 @@ To retrieve all flattened option values, you can simply omit passing a key:
 ```php
 $values = $this->value();
 ```
+
+## Command Autocomplete
+
+When asking for input from commands like the channel `id` above for `/ticket set channel <id>`, Laracord allows you to easily provide autocomplete results to assist the user.
+
+> #### Note
+>
+> Autocomplete choices may only contain up to 25 items at a time and will automatically be limited.
+
+How you can approach this is rather flexible and any command/subcommand can be targeted using dot-notation.
+
+In it's simplest form, you may pass a simple array of options to autocomplete to:
+
+```php
+/**
+ * Set the autocomplete choices.
+ */
+public function autocomplete(): array
+{
+    return [
+        'set.channel.id' => [
+            '00000',
+            '11111',
+        ],
+    ];
+}
+```
+
+By default, Laracord will automatically handle creating slug values out of passed options. To control the label and value yourself, you may pass them using key value pairs:
+
+```php
+/**
+ * Set the autocomplete choices.
+ */
+public function autocomplete(): array
+{
+    return [
+        'set.channel.id' => [
+            'General Chat' => '00000',
+            'Staff Chat' => '11111'
+        ],
+    ];
+}
+```
+
+For dynamic autocomplete choices, you may pass a callback instead consisting of the current state of the command interaction and the value they currently have entered:
+
+```php
+use Discord\Parts\Interactions\Interaction;
+
+/**
+ * Set the autocomplete choices.
+ */
+public function autocomplete(): array
+{
+    return [
+        'set.channel.id' => fn (Interaction $interaction, mixed $value) => $value
+            ? TicketChannel::where('channel_id', 'like', "%{$value}%")->take(25)->pluck('channel_id')
+            : TicketChannel::take(25)->pluck('channel_id'),
+    ];
+}
+```


### PR DESCRIPTION
- 📝 Add mention of Tinker to the installation page (Fixes #95)
- 📝 Add message documentation for edit, reply and editOrReply (Fixes #94)
- 📝 Expand on the `body` message documentation
- 📝 Add autocomplete documentation to slash commands (Fixes #92)